### PR TITLE
fix: Check permission before checking if discovering.

### DIFF
--- a/android/src/main/kotlin/com/kiwi/flutterscanbluetooth/FlutterScanBluetoothPlugin.kt
+++ b/android/src/main/kotlin/com/kiwi/flutterscanbluetooth/FlutterScanBluetoothPlugin.kt
@@ -96,9 +96,11 @@ class FlutterScanBluetoothPlugin
     }
 
     private fun onViewDestroy() {
-        if (adapter!!.isDiscovering) {
-            stopScan(null)
-        }
+        startPermissionValidation({
+            if (adapter!!.isDiscovering) {
+                stopScan(null)
+            }
+        })
     }
 
     private fun toMap(device: BluetoothDevice): Map<String, String> {


### PR DESCRIPTION
Stack trace in the wild:

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performDestroyActivity (ActivityThread.java:5950)
  at android.app.ActivityThread.handleDestroyActivity (ActivityThread.java:5995)
  at android.app.servertransaction.DestroyActivityItem.execute (DestroyActivityItem.java:47)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:45)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:176)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2438)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8663)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1135)
Caused by java.lang.SecurityException:
  at android.os.Parcel.createExceptionOrNull (Parcel.java:2438)
  at android.os.Parcel.createException (Parcel.java:2422)
  at android.os.Parcel.readException (Parcel.java:2405)
  at android.os.Parcel.readException (Parcel.java:2347)
  at android.bluetooth.IBluetooth$Stub$Proxy.isDiscovering (IBluetooth.java:5065)
  at android.bluetooth.BluetoothAdapter.isDiscovering (BluetoothAdapter.java:3004)
  at com.kiwi.flutterscanbluetooth.FlutterScanBluetoothPlugin.onViewDestroy (FlutterScanBluetoothPlugin.java)
  at com.kiwi.flutterscanbluetooth.FlutterScanBluetoothPlugin.onDetachedFromActivity (FlutterScanBluetoothPlugin.java)
  at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.detachFromActivity
  at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onDetach
  at io.flutter.embedding.android.FlutterActivity.onDestroy
  at android.app.Activity.performDestroy (Activity.java:8571)
  at android.app.Instrumentation.callActivityOnDestroy (Instrumentation.java:1364)
  at android.app.ActivityThread.performDestroyActivity (ActivityThread.java:5937)
```